### PR TITLE
Fix panic abort when private WebKit selectors are missing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,13 @@ impl<R: Runtime> MacFpsExt<R> for Webview<R> {
     fn unlock_fps(&self) -> tauri::Result<()> {
         #[cfg(target_os = "macos")]
         {
-            self.with_webview(|webview| unsafe {
-                macos::disable_60fps_cap(webview.inner());
+            self.with_webview(|webview| {
+                let ptr = webview.inner();
+                if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+                    macos::disable_60fps_cap(ptr);
+                })) {
+                    log::error!("tauri-plugin-macos-fps: panic in unlock_fps: {:?}", e);
+                }
             })?;
         }
         Ok(())
@@ -104,8 +109,13 @@ impl<R: Runtime> MacFpsExt<R> for Webview<R> {
     fn lock_fps(&self) -> tauri::Result<()> {
         #[cfg(target_os = "macos")]
         {
-            self.with_webview(|webview| unsafe {
-                macos::enable_60fps_cap(webview.inner());
+            self.with_webview(|webview| {
+                let ptr = webview.inner();
+                if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+                    macos::enable_60fps_cap(ptr);
+                })) {
+                    log::error!("tauri-plugin-macos-fps: panic in lock_fps: {:?}", e);
+                }
             })?;
         }
         Ok(())
@@ -147,8 +157,18 @@ pub fn init<R: Runtime>() -> TauriPlugin<R, Config> {
 
             #[cfg(target_os = "macos")]
             {
-                let _ = webview.with_webview(|wv| unsafe {
-                    macos::disable_60fps_cap(wv.inner());
+                let _ = webview.with_webview(|wv| {
+                    let ptr = wv.inner();
+                    if let Err(e) =
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+                            macos::disable_60fps_cap(ptr);
+                        }))
+                    {
+                        log::error!(
+                            "tauri-plugin-macos-fps: panic in on_webview_ready: {:?}",
+                            e
+                        );
+                    }
                 });
             }
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -12,8 +12,8 @@
 //! Each `_WKFeature` has a `.key` property. We find our target key and toggle it
 //! via `_setEnabled:forFeature:` on the preferences instance.
 
-use objc2::msg_send;
-use objc2::runtime::{AnyClass, AnyObject, Bool};
+use objc2::{msg_send, sel};
+use objc2::runtime::{AnyClass, AnyObject, Bool, Sel};
 
 const TARGET_KEY: &str = "PreferPageRenderingUpdatesNear60FPSEnabled";
 
@@ -47,6 +47,20 @@ unsafe fn set_60fps_cap(wk_webview_ptr: *mut std::ffi::c_void, enabled: bool) ->
         log::warn!("tauri-plugin-macos-fps: WKPreferences class not found");
         return false;
     };
+    // Verify the private _features selector exists before calling it.
+    // Without this check, msg_send! panics on unrecognized selectors, and
+    // that panic crosses the FFI boundary in with_webview — causing an abort.
+    let sel_features: Sel = sel!(_features);
+    let responds: Bool =
+        unsafe { msg_send![wk_prefs_class, respondsToSelector: sel_features] };
+    if !responds.as_bool() {
+        log::warn!(
+            "tauri-plugin-macos-fps: WKPreferences does not respond to _features \
+             (private API unavailable on this macOS version)"
+        );
+        return false;
+    }
+
     let features: *mut AnyObject = unsafe { msg_send![wk_prefs_class, _features] };
     if features.is_null() {
         log::warn!(
@@ -70,6 +84,18 @@ unsafe fn set_60fps_cap(wk_webview_ptr: *mut std::ffi::c_void, enabled: bool) ->
         // Compare the key string
         let key_nsstring = unsafe { &*(key as *const objc2_foundation::NSString) };
         if key_nsstring.to_string() == TARGET_KEY {
+            // Verify _setEnabled:forFeature: exists on this preferences instance
+            let sel_set: Sel = sel!(_setEnabled:forFeature:);
+            let can_set: Bool =
+                unsafe { msg_send![preferences, respondsToSelector: sel_set] };
+            if !can_set.as_bool() {
+                log::warn!(
+                    "tauri-plugin-macos-fps: WKPreferences does not respond to \
+                     _setEnabled:forFeature: (private API unavailable)"
+                );
+                return false;
+            }
+
             let objc_bool = Bool::new(enabled);
             let _: () =
                 unsafe { msg_send![preferences, _setEnabled: objc_bool, forFeature: feature] };


### PR DESCRIPTION
## Summary
- Add `respondsToSelector:` guards before calling private `_features` and `_setEnabled:forFeature:` selectors — prevents `msg_send!` from panicking on unrecognized selectors
- Wrap all `with_webview` closure bodies in `std::panic::catch_unwind` — catches any remaining unexpected panics before they cross the FFI boundary and cause an abort

## Context

Reported by @flazouh in [tauri-apps/tauri#13978](https://github.com/tauri-apps/tauri/issues/13978#issuecomment-4042589068). The crash message is:

```
panic in a function that cannot unwind
thread caused non-unwinding panic. aborting.
```

The root cause: `with_webview` dispatches through Objective-C, so Rust panics inside it cannot unwind across the FFI boundary.

Fixes #2

## Test plan
- [ ] Verify on macOS 13–15 with a ProMotion display that FPS unlocking still works
- [ ] Verify the plugin no longer panics on macOS versions where the private API is absent
- [ ] Verify graceful degradation: app runs at 60fps with a log warning instead of crashing